### PR TITLE
Implemented hessian to be able to use scipy methods that need the hessian matrix

### DIFF
--- a/bme_reweight.py
+++ b/bme_reweight.py
@@ -371,9 +371,16 @@ class Reweight:
             
             # gradient
             jac = self.exp_data[:,0] + lambdas*err - avg
-
+            
+            # hessian
+            q_w = np.dot(ww,self.sim_data)
+            hess = np.einsum('k, ki, kj->ij',ww,self.sim_data,
+                   self.sim_data) - \
+                   np.outer(q_w,q_w) + \
+                   np.diag(err)
+                   
             # divide by theta to avoid numerical problems
-            return  fun/self.theta,jac/self.theta
+            return  fun/self.theta,jac/self.theta, hess/self.theta
 
         
         
@@ -414,7 +421,7 @@ class Reweight:
             lambdas=np.zeros(self.exp_data.shape[0])
             if np.any(np.array(self.bounds)):
                 result = optimize.minimize(func_maxent_gauss,lambdas,
-                    options=opt,method=meth,  jac=True,
+                    options=opt,method=meth,  jac=True, hess=True,
                     bounds=self.bounds)
             else:
                 result = optimize.minimize(func_maxent_gauss,lambdas,

--- a/bme_reweight.py
+++ b/bme_reweight.py
@@ -14,7 +14,7 @@
 from __future__ import print_function
 
 import numpy as np
-from scipy import optimize
+from scipy import optimize #version >0.13.0 for dogleg optimizer
 import sys
 import warnings
         
@@ -212,7 +212,7 @@ def weight_exp(exp_file,sim_file,w0,w_opt,outfile,rows=[],cols=[]):
 class Reweight:
 
     # initialize
-    def __init__(self,verbose=True,w0=[],kbt=None):
+    def __init__(self,verbose=True,w0=[],kbt=None, opt_method="L-BFGS-B"):
 
         self.exp_data = []
         self.sim_data = []
@@ -235,7 +235,7 @@ class Reweight:
                 w0 = np.exp((w0-np.max(w0))/kbt)
             print("# Set non-uniform initial weights from file. Sum=", np.sum(w0), len(w0))
             self.w0 = np.copy(w0)/np.sum(w0)
-
+        self.opt_method = opt_method
     # add data to class
     def add_data(self,exp_data,sim_data,labels,bounds,cols):
 
@@ -407,7 +407,7 @@ class Reweight:
         if(method=="MAXENT"):
             
             opt={'maxiter':50000,'disp':False,'ftol':1.0e-10}
-            meth = "L-BFGS-B"
+            meth = self.opt_method
             lambdas=np.zeros(self.exp_data.shape[0])
 
             result = optimize.minimize(func_maxent_gauss,lambdas,options=opt,method=meth,jac=True,bounds=self.bounds)

--- a/bme_reweight.py
+++ b/bme_reweight.py
@@ -414,11 +414,11 @@ class Reweight:
             lambdas=np.zeros(self.exp_data.shape[0])
             if np.any(np.array(self.bounds)):
                 result = optimize.minimize(func_maxent_gauss,lambdas,
-                    options=opt,method=meth, tol=tol, jac=True,
+                    options=opt,method=meth,  jac=True,
                     bounds=self.bounds)
             else:
                 result = optimize.minimize(func_maxent_gauss,lambdas,
-			        options=opt,method=meth, tol=tol, jac=True)
+			        options=opt,method=meth, jac=True)
             arg = -np.sum(result.x[np.newaxis,:]*self.sim_data,axis=1)
             if(np.max(arg)>300.):arg -= np.max(arg)
 

--- a/bme_reweight.py
+++ b/bme_reweight.py
@@ -443,7 +443,6 @@ class Reweight:
         if(method=="MAXENT"):
             
             opt={'maxiter':50000,'disp':False}
-            tol = 1.0e-8
             meth = self.opt_method
             lambdas=np.zeros(self.exp_data.shape[0])
 
@@ -452,14 +451,14 @@ class Reweight:
                     meth = 'trust-constr'
                 result = optimize.minimize(func_maxent_gauss,lambdas,
                     options=opt,method=meth,  jac=True, 
-                    hess=hess_maxent_gauss, tol=tol,
+                    hess=hess_maxent_gauss,
                     bounds=self.bounds)
             else:
                 if meth == 'trust':
                     meth = 'trust-exact'
                 result = optimize.minimize(func_maxent_gauss,lambdas,
 			        options=opt,method=meth, jac=True, 
-			        hess=hess_maxent_gauss, tol=tol)
+			        hess=hess_maxent_gauss)
             arg = -np.sum(result.x[np.newaxis,:]*self.sim_data,axis=1)
             if(np.max(arg)>300.):arg -= np.max(arg)
 

--- a/bme_reweight.py
+++ b/bme_reweight.py
@@ -272,8 +272,10 @@ class Reweight:
             self.w0 = np.array(self.w0)[rows]/np.sum(np.array(self.w0[rows]))
             self.renormalize_w0= True
             
+        labels = np.array(labels)[cols]
         sim_data = np.array(sim_data1)[rows,:]
         sim_data = sim_data[:,cols]
+        exp_data = np.array(exp_data)[cols, :]
 
         if(data_type=="NOE"):
             sim_data = np.power(sim_data,-noe_power)

--- a/bme_reweight.py
+++ b/bme_reweight.py
@@ -451,13 +451,15 @@ class Reweight:
                 if meth == 'trust':
                     meth = 'trust-constr'
                 result = optimize.minimize(func_maxent_gauss,lambdas,
-                    options=opt,method=meth,  jac=True, hess=True,
+                    options=opt,method=meth,  jac=True, 
+                    hess=hess_maxent_gauss, tol=tol,
                     bounds=self.bounds)
             else:
                 if meth == 'trust':
                     meth = 'trust-exact'
                 result = optimize.minimize(func_maxent_gauss,lambdas,
-			        options=opt,method=meth, jac=True, hess=hess_maxent_gauss)
+			        options=opt,method=meth, jac=True, 
+			        hess=hess_maxent_gauss, tol=tol)
             arg = -np.sum(result.x[np.newaxis,:]*self.sim_data,axis=1)
             if(np.max(arg)>300.):arg -= np.max(arg)
 

--- a/bme_reweight.py
+++ b/bme_reweight.py
@@ -443,7 +443,7 @@ class Reweight:
         if(method=="MAXENT"):
             
             opt={'maxiter':50000,'disp':False}
-            tol = 1.0e-10
+            tol = 1.0e-8
             meth = self.opt_method
             lambdas=np.zeros(self.exp_data.shape[0])
 

--- a/bme_reweight.py
+++ b/bme_reweight.py
@@ -408,11 +408,17 @@ class Reweight:
         
         if(method=="MAXENT"):
             
-            opt={'maxiter':50000,'disp':False,'ftol':1.0e-10}
+            opt={'maxiter':50000,'disp':False}
+            tol = 1.0e-10
             meth = self.opt_method
             lambdas=np.zeros(self.exp_data.shape[0])
-
-            result = optimize.minimize(func_maxent_gauss,lambdas,options=opt,method=meth,jac=True,bounds=self.bounds)
+            if np.any(np.array(self.bounds)):
+                result = optimize.minimize(func_maxent_gauss,lambdas,
+                    options=opt,method=meth, tol=tol, jac=True,
+                    bounds=self.bounds)
+            else:
+                result = optimize.minimize(func_maxent_gauss,lambdas,
+			        options=opt,method=meth, tol=tol, jac=True)
             arg = -np.sum(result.x[np.newaxis,:]*self.sim_data,axis=1)
             if(np.max(arg)>300.):arg -= np.max(arg)
 


### PR DESCRIPTION
The use of the hessian matrix significantly improves convergence. 
* I've implemented the `hess_maxent_gauss` function to calculate the hessian.
* I've changed added an optional argument to the `Rewieght` method. The default is now to use `trust-constr` for problems with bounds and `trust-exact` for unbound problems. By setting `opt_method='L-BFGS-B'` the method that was the default previously can still be used.
* I've corrected some lines to work when `rows` and `cols` were specified.
